### PR TITLE
Update descriptions in readme & recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TeamCity GitHub Last Matching Ref Recipe
 
-This TeamCity recipe fetches the latest GitHub reference (branch or tag) that matches a given pattern — such as `tags/v1` or `heads/feature`. The result is stored in a configurable environment variable and can be used throughout your build pipeline.
+This TeamCity recipe fetches the last matching GitHub reference (branch or tag) that matches a given pattern — such as `tags/v1` or `heads/feature`. The result is stored in a configurable environment variable and can be used throughout your build pipeline.
 
 Ideal for release pipelines, dynamic versioning, or selecting the latest relevant code state from GitHub.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We are **TeamCity Certified** and **YouTrack Certified** developers, specializin
 
 ## Requirements
 
-You need to have TeamCity 2025.03 or later installed to use this recipe. If you are using an older version than 2025.07, you need to upload the `github-last-matching-ref.yaml`, which contains the complete recipe. If you are using TeamCity 2025.07 or later, you can use the `jjideenschmiede/github-last-matching-ref` recipe directly from the JetBrains Marketplace.
+You need to have TeamCity 2025.03 or later installed to use this recipe. If you are using an older version than 2025.07, you need to upload the `github-last-matching-ref.yml`, which contains the complete recipe. If you are using TeamCity 2025.07 or later, you can use the `jjideenschmiede/github-last-matching-ref` recipe directly from the JetBrains Marketplace.
 
 ## Build
 

--- a/src/recipe.yml
+++ b/src/recipe.yml
@@ -38,5 +38,5 @@ inputs:
         The name of the environment variable to store the last matching reference.
       default: "GITHUB_LATEST_REF"
 steps:
-  - name: Fetch latest GitHub release version
+  - name: Fetch last matching GitHub release version
     kotlin-script: !include src.main.kts

--- a/src/recipe.yml
+++ b/src/recipe.yml
@@ -1,8 +1,8 @@
 name: jjideenschmiede/github-last-matching-ref
-title: Fetch Latest GitHub Ref
+title: Fetch last matching GitHub reference
 version: 1.0.0
 description: |
-  Fetches the latest Git reference (branch or tag) from a GitHub repository
+  Fetches the last Git reference (branch or tag) from a GitHub repository
   that matches a specified pattern. The result is stored in an environment variable.
 inputs:
   - env.input_repository:
@@ -35,7 +35,7 @@ inputs:
       required: false
       label: Environment Variable Name
       description: |
-        The name of the environment variable to store the latest reference.
+        The name of the environment variable to store the last matching reference.
       default: "GITHUB_LATEST_REF"
 steps:
   - name: Fetch latest GitHub release version


### PR DESCRIPTION
Refines documentation to emphasize finding the last matching GitHub reference rather than the latest. Updates README and YAML configurations to correct terminology, enhancing clarity for users relying on accurate descriptions of TeamCity recipe functionality. This change is critical to prevent misunderstanding of the matched reference's purpose.